### PR TITLE
Fix warning for delete instance property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,7 @@ const VueToastGroup = {
     this.$set(this.$toasts, name, toastProp);
   },
   beforeDestroy() {
-    this.$delete(this, this.name);
+    this.$set(this, this.name, null);
   },
   render(h) {
     return h(


### PR DESCRIPTION
Fix for 
[Vue warn]: Avoid deleting properties on a Vue instance or its root $data - just set it to null.

Just change from $delete to $set and set its value to null.